### PR TITLE
Resend email verification link

### DIFF
--- a/src/Analysim.Web/ClientApp/src/app/login/login.component.html
+++ b/src/Analysim.Web/ClientApp/src/app/login/login.component.html
@@ -21,7 +21,9 @@
                         
                                             <!-- Login Form Error -->
                                             <div class="text-center alert alert-warning alert-dismissible" *ngIf="invalidLogin" role="alert">
-                                                <strong>{{errorMessage}}</strong>
+                                              <strong>{{errorMessage}}
+                                              <span *ngIf="emailConf">
+                                                <a href="javascript:void(0);" (click)="sendReverifyLink()"> Click here to resend the email</a>.</span></strong>
                                                 <button type="button" class="close" data-dismiss="alert" aria-label="Close" (click)="invalidLogin = null;">
                                                     <span aria-hidden="true">&times;</span>
                                                 </button>
@@ -76,21 +78,6 @@
                                         <a [routerLink]='["/register"]' [queryParams]="{returnUrl: returnUrl}" *ngIf="returnUrl != ''">Sign Up</a>
                                         <a [routerLink]='["/register"]' *ngIf="returnUrl == ''">Sign Up</a>
                                     </div>
-                                </article>
-                            </div> <!-- card.// -->
-                        </div>
-                    </div>  <!-- Row End -->
-                    <!-- Row Start -->
-                    <div class="row justify-content-center">
-                        <div class="col-md-4 mb-4">
-                            <div class="card bg-theme">
-                                <article class="card-body">
-                                    <div class="text-center">
-                                        <p class ="d-inline">Resend Email Verification link </p>
-                                        <a [routerLink]='["/email-resend-verification"]' [queryParams]="{returnUrl: 'login'}" *ngIf="returnUrl != ''">Resend</a>
-                                        <a [routerLink]='["/email-resend-verification"]' *ngIf="returnUrl == ''">Resend</a>
-                                    </div>
-                                    
                                 </article>
                             </div> <!-- card.// -->
                         </div>

--- a/src/Analysim.Web/ClientApp/src/app/login/login.component.ts
+++ b/src/Analysim.Web/ClientApp/src/app/login/login.component.ts
@@ -16,6 +16,7 @@ export class LoginComponent implements OnInit {
   password: FormControl;
   returnUrl: string;
   errorMessage: string;
+  emailConf: string;
   invalidLogin: boolean;
   isLoading: boolean;
 
@@ -62,12 +63,28 @@ export class LoginComponent implements OnInit {
         this.isLoading = false;
         this.invalidLogin = true;
         this.errorMessage = error.error.loginError;
+        if ("emailConf" in error.error) {
+          this.emailConf = error.error.emailConf;
+        } else this.emailConf = '';
       },
     );
   }
 
   forgotPasswordPage() {
     this.router.navigate(['/emailForgotPass']);
+  }
+
+  sendReverifyLink() {
+    this.acct.resendVerificationLink(this.emailConf).subscribe(
+      result => {
+        this.router.navigate(['/login']);
+        this.notfi.showInfo('Email confirmation sent successfully!', 'Check your email.');
+      },
+      error => {
+        this.isLoading = false;
+        this.errorMessage = error.error.Message;
+      }
+    );
   }
 
 }

--- a/src/Analysim.Web/ClientApp/src/app/services/account.service.ts
+++ b/src/Analysim.Web/ClientApp/src/app/services/account.service.ts
@@ -217,11 +217,10 @@ export class AccountService {
   }
 
   resendVerificationLink(email: string) {
-    console.log("resendVerificationLink is called")
-    let body = new FormData()
-    body.append('EmailAddress', email)
+    let params = new HttpParams();
+    params = params.append("EmailAddress", email);
 
-    return this.http.post<any>(this.urlReSendVerification, body)
+    return this.http.get<any>(this.urlReSendVerification, { params: params })
       .pipe(
         map(body => {
           return body

--- a/src/Analysim.Web/Controllers/AccountController.cs
+++ b/src/Analysim.Web/Controllers/AccountController.cs
@@ -324,14 +324,13 @@ namespace Web.Controllers
          * Description: Verifies the user from the token sent from Register
          * Response Status: 200 Ok, 401 Unauthorized
          */
-        [HttpPost("[action]")]
-        public async Task<IActionResult> SendConfirmationEmail([FromForm] ForgotPasswordVM formdata)
+        [HttpGet("[action]")]
+        public async Task<IActionResult> SendConfirmationEmail([FromQuery(Name = "EmailAddress")] string email)
         {
-            var user = await _userManager.FindByEmailAsync(formdata.EmailAddress);
+            var user = await _userManager.FindByEmailAsync(email);
 
             // generate email token
             var code = await _userManager.GenerateEmailConfirmationTokenAsync(user);
-            
 
             var callbackUrl = Url.Action("ConfirmEmail", "Account", new
                 {
@@ -498,7 +497,8 @@ namespace Web.Controllers
                 {
                     return Unauthorized(new
                     {
-                        LoginError = "Please verify your account email"
+                        LoginError = $"Please verify your account by clicking the link in the email that you received.",
+                        EmailConf = user.Email
                     });
                 }
 


### PR DESCRIPTION
Only show the link when a login attempt fails with unverified account. Removed link to obsolete interface, but didn't remove the page.