### PR TITLE
Implement sending the success email after email verification

### DIFF
--- a/src/Analysim.Web/ClientApp/src/app/register/register.component.ts
+++ b/src/Analysim.Web/ClientApp/src/app/register/register.component.ts
@@ -66,6 +66,7 @@ export class RegisterComponent implements OnInit {
         // Hide Error Message Box
         this.invalidRegister = false
 
+        /*
         const username = userReg.username
         const emailAddress = userReg.emailAddress
         const subject: string = "Registration Complete"
@@ -80,6 +81,10 @@ export class RegisterComponent implements OnInit {
             console.log(error)
           }
         );
+
+        */
+
+
 
         // Navigate to login page
         if (this.returnUrl == "")

--- a/src/Analysim.Web/Controllers/AccountController.cs
+++ b/src/Analysim.Web/Controllers/AccountController.cs
@@ -299,7 +299,6 @@ namespace Web.Controllers
             System.Diagnostics.Debug.WriteLine("Token: " + token + "\n" + "UserID: " + userID);
             var user = await _userManager.FindByIdAsync(userID);
 
-
             // var decodedTokenString = Encoding.UTF8.GetString(WebEncoders.Base64UrlDecode(token));
 
             if (!await _userManager.IsEmailConfirmedAsync(user))
@@ -307,6 +306,8 @@ namespace Web.Controllers
                 System.Diagnostics.Debug.WriteLine("User is NOT verified");
                 await _userManager.ConfirmEmailAsync(user, token);
                 System.Diagnostics.Debug.WriteLine("User is verified");
+                var emailContent = "<p>You have been successfully registered for the AnalySim website.</p>";
+                await _mailNetService.SendEmail(user.Email, user.UserName, "Registration Complete", emailContent, emailContent);
                 return Redirect("~/email-confirmation");   
             }
 


### PR DESCRIPTION
I removed the service of sending the registration success email after registration from the front-end. I added it to the backend service in the ConfirmEmail function. It sends the registration success email once the email is confirmed.