### PR TITLE
Fix registration error handling to reflect internal errors in the UI

### DIFF
--- a/src/Analysim.Web/ClientApp/src/app/register/register.component.ts
+++ b/src/Analysim.Web/ClientApp/src/app/register/register.component.ts
@@ -135,7 +135,13 @@ export class RegisterComponent implements OnInit {
         this.invalidRegister = true;
 
         //Set Error Message
-        this.errorMessage = error.error.message[0];
+        if (error.error.Message) {
+          this.errorMessage = error.error.Message;
+        }
+        else {
+          this.errorMessage = error.error.message[0];
+        }
+        
       }
     );
 


### PR DESCRIPTION
After a user successfully registers, if any internal error occurs (e.g., during email sending or other post-registration processes), the error is not properly reflected in the UI The UI shows an empty box. This prevents users from understanding the issue and taking appropriate action.

Before:
![4](https://github.com/user-attachments/assets/2bde6bd7-769d-4841-95ad-41b7729867a2)


After fixing the issue:
![error](https://github.com/user-attachments/assets/b6cc476b-b7b3-422e-929a-6bccd79980f3)

Fixes https://github.com/soft-eng-practicum/AnalySim/issues/89
