### PR TITLE
Upload File Issue resolved

### DIFF
--- a/src/Analysim.Web/Controllers/ProjectController.cs
+++ b/src/Analysim.Web/Controllers/ProjectController.cs
@@ -830,7 +830,7 @@ namespace Web.Controllers
                     Uri = "",
                     DateCreated = DateTimeOffset.UtcNow,
                     LastModified = DateTimeOffset.UtcNow,
-                    UserID = formdata.UserID,
+                    UserID = user.Id,
                     ProjectID = formdata.ProjectID
                 };
 


### PR DESCRIPTION
The current implementation of the _/api/project/uploadfile_ endpoint uses `formdata.UserID` as the `UserID`. However, `formdata` does not contain a `UserID`, resulting in a Bad Request error. I've resolved this issue by using the authenticated `user.Id` instead, which is also a better practice.