### PR TITLE
Add health endpoint and backend smoke test CI workflow

### DIFF
--- a/.github/workflows/backend-smoke-test.yml
+++ b/.github/workflows/backend-smoke-test.yml
@@ -1,0 +1,78 @@
+name: Backend Smoke Test
+
+on:
+  pull_request:
+    branches: [develop]
+  push:
+    branches: [develop]
+
+jobs:
+  backend-smoke-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 6.0.x
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Create appsettings.json
+        run: |
+          cat <<EOF > src/Analysim.Web/appsettings.json
+          {
+            "JwtSettings": {
+              "Issuer": "AnalySim",
+              "Secret": "very_hard_secret",
+              "ExpireTime": 60,
+              "Audience": "https://www.analysim.tech/"
+            },
+            "Logging": {
+              "LogLevel": {
+                "Default": "Information",
+                "Microsoft": "Warning"
+              }
+            },
+            "AllowedHosts": "*"
+          }
+          EOF
+
+      - name: Build backend
+        run: dotnet build --no-restore --configuration Release
+
+      - name: Start backend
+        run: |
+          cd src/Analysim.Web
+          dotnet run --no-launch-profile > ../../backend.log 2>&1 &
+          echo $! > ../../backend.pid
+
+      - name: Wait for backend to be ready
+        run: |
+          for i in {1..15}; do
+            RESPONSE=$(curl -k -s https://localhost:5001/api/health || true)
+
+            if [[ "$RESPONSE" == *Healthy* ]]; then
+              echo "Backend is healthy"
+              exit 0
+            fi
+
+            echo "Attempt $i/30: backend not ready yet"
+            sleep 6
+          done
+
+          echo "Backend failed to become ready"
+          echo "===== Backend log ====="
+          cat backend.log
+          exit 1
+
+      - name: Stop backend
+        if: always()
+        run: |
+          if [ -f backend.pid ]; then
+            kill $(cat backend.pid) || true
+          fi

--- a/src/Analysim.Web/Controllers/HealthController.cs
+++ b/src/Analysim.Web/Controllers/HealthController.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Analysim.Web.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class HealthController : ControllerBase
+{
+    [HttpGet]
+    public IActionResult get()
+    {
+        return Ok("Healthy");
+    }
+}


### PR DESCRIPTION
This PR introduces a simple backend smoke test to ensure the application starts correctly and responds to basic health checks.

## Changes

- Added a new `/api/health` endpoint returning `Healthy`
- Added a GitHub Actions workflow that:
  - Builds the backend
  - Starts the application without a launch profile
  - Polls the `/api/health` endpoint until the backend is ready

This helps detect startup issues early and improves CI reliability.

## CI Smoke Test Results

<table>
<tr>
<td align="center"><b>Successful run</b></td>
<td align="center"><b>Failing run</b></td>
</tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/ce6b81d9-65e2-4194-8aa3-05f49bdf6443" width="450"/></td>
<td><img src="https://github.com/user-attachments/assets/8ac27114-15f8-4cb5-a7e0-b4c107251239" width="450"/></td>
</tr>
</table>
