### PR TITLE
Fix duplicate project names for the same user

### DIFF
--- a/src/Analysim.Web/ClientApp/src/app/projects/project-create/project-form-create/project-form-create.component.html
+++ b/src/Analysim.Web/ClientApp/src/app/projects/project-create/project-form-create/project-form-create.component.html
@@ -31,6 +31,10 @@
     </div>
 
     <!-- Form Create Project -->
+    <div *ngIf="submitErrorMessage" class="form-group mb-2">
+        <div class="alert alert-danger mb-0" role="alert">{{ submitErrorMessage }}</div>
+    </div>
+
     <div class="form-group mb-0">
         <button id="success-btn"  type="submit" class="btn btn-success btn-block" value="Submit" [disabled]="projectForm.invalid">
             <div *ngIf="!isLoading">

--- a/src/Analysim.Web/ClientApp/src/app/projects/project-create/project-form-create/project-form-create.component.ts
+++ b/src/Analysim.Web/ClientApp/src/app/projects/project-create/project-form-create/project-form-create.component.ts
@@ -29,6 +29,7 @@ export class ProjectFormCreateComponent implements OnInit {
   currentUser$ : Observable<User>
   currentUser : User
   isLoading : boolean
+  submitErrorMessage: string
 
   @Output() setProject = new EventEmitter<Project>()
 
@@ -37,6 +38,7 @@ export class ProjectFormCreateComponent implements OnInit {
       this.router.navigate(['/login'], {queryParams: {returnUrl : this.router.url}})
 
     this.isLoading = false;
+    this.submitErrorMessage = '';
 
     await this.accountService.currentUser.then((x) => this.currentUser$ = x)
     this.currentUser$.subscribe(x => this.currentUser = x)
@@ -80,11 +82,16 @@ export class ProjectFormCreateComponent implements OnInit {
 
   onSubmit() {
     let projectForm = this.projectForm.value;
+    this.submitErrorMessage = '';
+    this.isLoading = true;
 
     this.projectService.createProject(this.currentUser, projectForm.name, projectForm.visibility, projectForm.description).subscribe(
       result =>{
+        this.isLoading = false;
         this.setProject.emit(result)
       },error =>{
+        this.isLoading = false;
+        this.submitErrorMessage = error?.error?.message || 'Failed to create project.';
         console.log(error)
       }
     )

--- a/src/Analysim.Web/Controllers/ProjectController.cs
+++ b/src/Analysim.Web/Controllers/ProjectController.cs
@@ -700,7 +700,7 @@ namespace Web.Controllers
             // Check if the project already exists
             bool projectExists = await _dbContext.Projects
                 .AnyAsync(p => p.ProjectUsers.Any(aup =>
-                    aup.User.Id == formdata.UserID &&
+                    aup.UserID == userId &&
                     aup.Project.Name == formdata.Name &&
                     aup.UserRole == "owner"));
 


### PR DESCRIPTION
Fixed duplicate project creation for the same user.  
`CreateProject` was using `formdata.UserID` instead of the authenticated user ID from JWT claims. Since the frontend does not send `UserID` in the create request, the duplicate check was bypassed in practice. The check now uses the server-side authenticated user ID, and the frontend displays the conflict message.

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/4653d290-2973-49e4-b795-c51f6d8c0b30" width="450" />
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/593b23d4-6c9b-4f41-afa9-bdd7ab189267" width="450" />
    </td>
  </tr>
</table>