### PR TITLE
feat: enable users to follow and unfollow projects

### DIFF
--- a/src/Analysim.Core/Entities/ProjectComment.cs
+++ b/src/Analysim.Core/Entities/ProjectComment.cs
@@ -1,3 +1,5 @@
+#nullable enable annotations
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/src/Analysim.Core/Entities/ProjectLog.cs
+++ b/src/Analysim.Core/Entities/ProjectLog.cs
@@ -1,3 +1,5 @@
+#nullable enable annotations
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/src/Analysim.Core/Entities/Publication.cs
+++ b/src/Analysim.Core/Entities/Publication.cs
@@ -1,3 +1,5 @@
+#nullable enable annotations
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;

--- a/src/Analysim.Web/ClientApp/src/app/projects/project/project.component.html
+++ b/src/Analysim.Web/ClientApp/src/app/projects/project/project.component.html
@@ -176,8 +176,30 @@
                 <a class="more-link" role="button" tabindex="0">Recommend</a>
                 <a class="more-link" role="button" tabindex="0" *ngIf="!isMember && !isOwner">Join</a>
                 <a class="more-link" role="button" tabindex="0" *ngIf="isMember && !isOwner">Leave</a>
-                <a class="more-link" role="button" tabindex="0" *ngIf="!isFollowing">Follow</a>
-                <a class="more-link" role="button" tabindex="0" *ngIf="isFollowing">Unfollow</a>
+                <a
+                  class="more-link"
+                  role="button"
+                  tabindex="0"
+                  *ngIf="!isFollowing"
+                  (click)="followProject()"
+                  (keydown.enter)="followProject()"
+                  (keydown.space)="followProject(); $event.preventDefault()"
+                  [class.is-disabled]="isFollowLoading"
+                  [attr.aria-disabled]="isFollowLoading">
+                  Follow
+                </a>
+                <a
+                  class="more-link"
+                  role="button"
+                  tabindex="0"
+                  *ngIf="isFollowing"
+                  (click)="unFollowProject()"
+                  (keydown.enter)="unFollowProject()"
+                  (keydown.space)="unFollowProject(); $event.preventDefault()"
+                  [class.is-disabled]="isFollowLoading"
+                  [attr.aria-disabled]="isFollowLoading">
+                  Unfollow
+                </a>
               </div>
 
               <button type="button"

--- a/src/Analysim.Web/ClientApp/src/app/projects/project/project.component.scss
+++ b/src/Analysim.Web/ClientApp/src/app/projects/project/project.component.scss
@@ -384,6 +384,11 @@
           color: var(--link-hover-color);
           text-decoration: underline;
         }
+
+        &.is-disabled {
+          opacity: .6;
+          pointer-events: none;
+        }
       }
 
       .more-toggle {

--- a/src/Analysim.Web/ClientApp/src/app/projects/project/project.component.ts
+++ b/src/Analysim.Web/ClientApp/src/app/projects/project/project.component.ts
@@ -302,6 +302,8 @@ export class ProjectComponent implements OnInit {
   }
 
   followProject() {
+    if (this.isFollowLoading) return
+
     // Navigate To Login Page If User Not Logged In
     if (!this.accountService.checkLoginStatus()) {
       this.router.navigate(['/login'], { queryParams: { returnUrl: this.router.url } })
@@ -354,6 +356,7 @@ export class ProjectComponent implements OnInit {
   }
 
   unFollowProject() {
+    if (this.isFollowLoading) return
     if(!this.projectUser) return
 
     this.isFollowLoading = true

--- a/src/Analysim.Web/ClientApp/src/app/projects/project/project.component.ts
+++ b/src/Analysim.Web/ClientApp/src/app/projects/project/project.component.ts
@@ -47,6 +47,7 @@ export class ProjectComponent implements OnInit {
   currentUser$: Observable<User> = null
   currentUser: User = null
   projectUser: ProjectUser = null
+  isFollowLoading: boolean = false
   fileDirectory: string
   forkedFrom: Project = null
   profileImageUrls: { [key: string]: SafeUrl } = {};
@@ -306,55 +307,86 @@ export class ProjectComponent implements OnInit {
       this.router.navigate(['/login'], { queryParams: { returnUrl: this.router.url } })
     }
     else {
+      this.isFollowLoading = true
+
+      const prevProjectUsers = [...this.project.projectUsers]
+      const prevProjectUser = this.projectUser
+
       if (this.projectUser == null) {
-        // Create Project User As Follower
-        this.projectService.addUser(this.project.projectID, this.currentUser.id, "follower", true).subscribe(
-          result => {
-            this.project.projectUsers.push(result)
-            this.projectUser = result;
-          }, error => {
-            console.log(error)
-          }
-        )
+        const placeholder: ProjectUser = {
+          projectID: this.project.projectID,
+          userID: this.currentUser.id,
+          userRole: 'follower',
+          isFollowing: true,
+          user: this.currentUser
+        } as any
+
+        this.project.projectUsers.push(placeholder)
+        this.projectUser = placeholder
+
+        this.projectService.followProject(this.project.projectID).subscribe(result => {
+          this.project.projectUsers = this.project.projectUsers.map(pu => pu.userID == result.userID ? result : pu)
+          this.projectUser = result
+          this.isFollowLoading = false
+        }, error => {
+          console.log(error)
+          this.project.projectUsers = prevProjectUsers
+          this.projectUser = prevProjectUser
+          this.isFollowLoading = false
+        })
       }
       else {
-        // Modify Project User And Set Following To True
-        this.projectUser.isFollowing = true;
-        this.projectService.updateUser(this.projectUser).subscribe(
-          result => {
-            let index = this.project.projectUsers.findIndex(pu => pu.userID == result.userID)
-            this.project.projectUsers[index] = result
-            this.projectUser = result;
-          }, error => {
-            console.log(error)
-          }
-        )
+        const prev = this.projectUser.isFollowing
+        this.projectUser.isFollowing = true
+
+        this.projectService.followProject(this.project.projectID).subscribe(result => {
+          let index = this.project.projectUsers.findIndex(pu => pu.userID == result.userID)
+          if (index > -1) this.project.projectUsers[index] = result
+          this.projectUser = result;
+          this.isFollowLoading = false
+        }, error => {
+          console.log(error)
+          this.projectUser.isFollowing = prev
+          this.isFollowLoading = false
+        })
       }
     }
   }
 
   unFollowProject() {
-    this.projectUser.isFollowing = false
-    if (this.projectUser.userRole == "follower")
-      this.projectService.removeUser(this.projectUser.projectID, this.projectUser.userID).subscribe(
-        result => {
-          let index = this.project.projectUsers.indexOf(result)
-          this.project.projectUsers.splice(index, 1)
-          this.projectUser = null
-        }, error => {
-          console.log(error)
-        }
-      )
+    if(!this.projectUser) return
+
+    this.isFollowLoading = true
+
+    const prevProjectUsers = [...this.project.projectUsers]
+    const prevProjectUser = { ...this.projectUser }
+
+    if (this.projectUser.userRole == "follower"){
+      const idx = this.project.projectUsers.findIndex(pu => pu.userID == this.projectUser.userID)
+      if(idx > -1) this.project.projectUsers.splice(idx, 1)
+      this.projectUser = null
+
+      this.projectService.unfollowProject(prevProjectUser.projectID).subscribe(result =>{
+        this.isFollowLoading = false
+      }, error =>{
+        console.log(error)
+        this.project.projectUsers = prevProjectUsers
+        this.projectUser = prevProjectUser
+        this.isFollowLoading = false
+      })
+    }
     else {
-      this.projectService.updateUser(this.projectUser).subscribe(
-        result => {
-          let index = this.project.projectUsers.findIndex(pu => pu.userID == result.userID)
-          this.project.projectUsers[index] = result
-          this.projectUser = result
-        }, error => {
-          console.log(error)
-        }
-      )
+      this.projectUser.isFollowing = false
+      this.projectService.unfollowProject(this.projectUser.projectID).subscribe(result => {
+        let index = this.project.projectUsers.findIndex(pu => pu.userID == result.userID)
+        if(index > -1) this.project.projectUsers[index] = result
+        this.projectUser = result
+        this.isFollowLoading = false
+      }, error => {
+        console.log(error)
+        this.projectUser = prevProjectUser
+        this.isFollowLoading = false
+      })
     }
   }
 

--- a/src/Analysim.Web/ClientApp/src/app/services/project.service.ts
+++ b/src/Analysim.Web/ClientApp/src/app/services/project.service.ts
@@ -54,6 +54,8 @@ export class ProjectService {
   // Post
   private urlCreateProject: string = this.baseUrl + "createproject"
   private urlAddUser: string = this.baseUrl + "adduser"
+  private urlFollowProject: string = this.baseUrl + "followproject/"
+  private urlUnfollowProject: string = this.baseUrl + "unfollowproject/"
   private urlAddTag: string = this.baseUrl + "addtag"
   private urlUploadFile: string = this.baseUrl + "uploadfile"
   private urlCreateFolder: string = this.baseUrl + "createFolder"
@@ -355,6 +357,36 @@ export class ProjectService {
           return throwError(error)
         })
       )
+  }
+
+  followProject(projectID: number): Observable<ProjectUser> {
+    const headers = new HttpHeaders().set('Authorization', `Bearer ${localStorage.getItem('jwt')}`);
+
+    return this.http.post<any>(this.urlFollowProject + projectID, null, { headers }).pipe(
+      map(body => {
+        console.log(body.message)
+        return body.result
+      }),
+      catchError(error => {
+        console.log(error)
+        return throwError(error)
+      })
+    )
+  }
+
+  unfollowProject(projectID: number): Observable<ProjectUser> {
+    const headers = new HttpHeaders().set('Authorization', `Bearer ${localStorage.getItem('jwt')}`);
+
+    return this.http.delete<any>(this.urlUnfollowProject + projectID, { headers }).pipe(
+      map(body => {
+        console.log(body.message)
+        return body.result
+      }),
+      catchError(error => {
+        console.log(error)
+        return throwError(error)
+      })
+    )
   }
 
   addTag(projectID: number, tagName: string): Observable<ProjectTag> {

--- a/src/Analysim.Web/ClientApp/src/app/shared/project-card/project-card.component.html
+++ b/src/Analysim.Web/ClientApp/src/app/shared/project-card/project-card.component.html
@@ -12,7 +12,7 @@
       <!-- Follow/UnFollow Project -->
       <div class="project-follow-option">
         <!-- Follow Project Button -->
-        <button class="btn btn-primary" type="button" *ngIf="!isFollowing" (click)="followProject()">
+        <button class="btn btn-primary" type="button" *ngIf="!isFollowing" (click)="followProject()" [disabled]="isFollowLoading">
           Follow
           <span class="badge badge-light font-weight-light ml-1">
             {{ project | role:"follower" }}
@@ -20,7 +20,7 @@
         </button>
   
         <!-- UnFollow Project Button -->
-        <button class="btn btn-primary" type="button" *ngIf="isFollowing" (click)="unFollowProject()">
+        <button class="btn btn-primary" type="button" *ngIf="isFollowing" (click)="unFollowProject()" [disabled]="isFollowLoading">
           Unfollow
           <span class="badge badge-light font-weight-light ml-1">
             {{ project | role:"follower" }}

--- a/src/Analysim.Web/ClientApp/src/app/shared/project-card/project-card.component.ts
+++ b/src/Analysim.Web/ClientApp/src/app/shared/project-card/project-card.component.ts
@@ -30,6 +30,7 @@ export class ProjectCardComponent implements OnInit {
   currentUser$ : Observable<User>
   currentUser : User = null
   projectUser : ProjectUser = null
+  isFollowLoading: boolean = false
 
   async ngOnInit() {
     // Get User And Check For Project User Match
@@ -105,59 +106,98 @@ export class ProjectCardComponent implements OnInit {
 
   followProject(){
     // Navigate To Login Page If User Not Logged In
-    if(!this.accountService.checkLoginStatus())
+    if(!this.accountService.checkLoginStatus()){
       this.router.navigate(['/login'], {queryParams: {returnUrl : this.router.url}})
+      return
+    }
+
+    this.isFollowLoading = true
+
+    const prevProjectUsers = [...this.project.projectUsers]
+    const prevProjectUser = this.projectUser
 
     if(this.projectUser == null)
     {
-      // Create Project User As Follower
-      this.projectService.addUser(this.project.projectID, this.currentUser.id, "follower", true).subscribe(
-        result =>{
-          this.project.projectUsers.push(result) 
-          this.projectUser = result;  
-        }, error =>{
-          console.log(error)
-        }
-      )
+      // optimistic placeholder
+      const placeholder: ProjectUser = {
+        projectID: this.project.projectID,
+        userID: this.currentUser.id,
+        userRole: 'follower',
+        isFollowing: true,
+        user: this.currentUser
+      } as any
+
+      this.project.projectUsers.push(placeholder)
+      this.projectUser = placeholder
+
+      this.projectService.followProject(this.project.projectID).subscribe(result =>{
+        const idx = this.project.projectUsers.findIndex(pu => pu.userID == result.userID)
+        if(idx > -1) this.project.projectUsers[idx] = result
+        this.projectUser = result
+        this.isFollowLoading = false
+      }, error =>{
+        console.log(error)
+        this.project.projectUsers = prevProjectUsers
+        this.projectUser = prevProjectUser
+        this.isFollowLoading = false
+      })
     }
     else{
-      // Modify Project User And Set Following To True
-      this.projectUser.isFollowing = true;     
-      this.projectService.updateUser(this.projectUser).subscribe(
-        result =>{
-          let index = this.project.projectUsers.findIndex(pu => pu.userID == result.userID)
-          this.project.projectUsers[index] = result
-          this.projectUser = result;          
-        }, error =>{
-          console.log(error)
-        }
-      )
+      // optimistic toggle
+      const prev = this.projectUser.isFollowing
+      this.projectUser.isFollowing = true
+
+      this.projectService.followProject(this.project.projectID).subscribe(result =>{
+        let index = this.project.projectUsers.findIndex(pu => pu.userID == result.userID)
+        if(index > -1) this.project.projectUsers[index] = result
+        this.projectUser = result
+        this.isFollowLoading = false
+      }, error =>{
+        console.log(error)
+        this.projectUser.isFollowing = prev
+        this.isFollowLoading = false
+      })
     }
   }
 
 
   unFollowProject(){
-    this.projectUser.isFollowing = false
-    if(this.projectUser.userRole == "follower")
-      this.projectService.removeUser(this.projectUser.projectID, this.projectUser.userID).subscribe(
-        result => {
-          let index = this.project.projectUsers.indexOf(result)
-          this.project.projectUsers.splice(index, 1)
-          this.projectUser = null
-        }, error =>{
-          console.log(error)
-        }
-      )
+    if(!this.projectUser) return
+
+    this.isFollowLoading = true
+
+    const prevProjectUsers = [...this.project.projectUsers]
+    const prevProjectUser = { ...this.projectUser }
+
+    if(this.projectUser.userRole == "follower"){
+      // optimistic remove
+      const idx = this.project.projectUsers.findIndex(pu => pu.userID == this.projectUser.userID)
+      if(idx > -1) this.project.projectUsers.splice(idx, 1)
+      this.projectUser = null
+
+      this.projectService.unfollowProject(prevProjectUser.projectID).subscribe(result =>{
+        // nothing to do, server handled removal or returned updated row
+        this.isFollowLoading = false
+      }, error =>{
+        console.log(error)
+        this.project.projectUsers = prevProjectUsers
+        this.projectUser = prevProjectUser
+        this.isFollowLoading = false
+      })
+    }
     else{
-      this.projectService.updateUser(this.projectUser).subscribe(
-        result => {
-          let index = this.project.projectUsers.findIndex(pu => pu.userID == result.userID)
-          this.project.projectUsers[index] = result
-          this.projectUser = result 
-        }, error =>{
-          console.log(error)
-        }
-      )
+      // user is member/owner — set isFollowing = false
+      this.projectUser.isFollowing = false
+      this.projectService.unfollowProject(this.projectUser.projectID).subscribe(result =>{
+        const i = this.project.projectUsers.findIndex(pu => pu.userID == result.userID)
+        if(i > -1) this.project.projectUsers[i] = result
+        this.projectUser = result
+        this.isFollowLoading = false
+      }, error =>{
+        console.log(error)
+        this.projectUser = prevProjectUser
+        this.isFollowLoading = false
+      })
     }
   }
 

--- a/src/Analysim.Web/Controllers/ProjectController.cs
+++ b/src/Analysim.Web/Controllers/ProjectController.cs
@@ -1903,6 +1903,173 @@ namespace Web.Controllers
 
         /*
          * Type : POST
+         * URL : /api/project/followproject/{projectID}
+         * Description: Follow a project as the authenticated user.
+         *
+         * Request example:
+         * POST /api/project/followproject/42
+         *
+         * Response example:
+         * {
+         *   "result": {
+         *     "userID": 5,
+         *     "projectID": 42,
+         *     "userRole": "follower",
+         *     "isFollowing": true
+         *   },
+         *   "message": "Project followed successfully."
+         * }
+         */
+        [Authorize]
+        [HttpPost("[action]/{projectID}")]
+        public async Task<IActionResult> FollowProject([FromRoute] int projectID)
+        {
+            if (projectID <= 0)
+                return BadRequest(new { message = "Invalid project id." });
+
+            // Find User
+            var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (string.IsNullOrEmpty(userIdClaim) || !int.TryParse(userIdClaim, out var userId))
+            {
+                return Unauthorized(new { message = "Invalid user identifier." });
+            }
+
+            var user = await _dbContext.Users.SingleOrDefaultAsync(u => u.Id == userId);
+            if (user == null) return NotFound(new { message = "Current user not found" });
+
+            var project = await _dbContext.Projects.FindAsync(projectID);
+            if (project == null) return NotFound(new { message = "Project Not Found" });
+
+            var projectUser = await _dbContext.ProjectUsers.FindAsync(user.Id, projectID);
+
+            if (projectUser != null)
+            {
+                if (!string.Equals(projectUser.UserRole, "follower", StringComparison.OrdinalIgnoreCase))
+                {
+                    return Conflict(new
+                    {
+                        result = projectUser,
+                        message = "Project membership already exists and cannot be changed to a follower record."
+                    });
+                }
+
+                if (projectUser.IsFollowing)
+                {
+                    return Ok(new
+                    {
+                        result = projectUser,
+                        message = "Project is already followed."
+                    });
+                }
+
+                projectUser.IsFollowing = true;
+                _dbContext.Entry(projectUser).State = EntityState.Modified;
+                await _dbContext.SaveChangesAsync();
+
+                return Ok(new
+                {
+                    result = projectUser,
+                    message = "Project followed successfully."
+                });
+            }
+
+            projectUser = new ProjectUser
+            {
+                UserID = user.Id,
+                ProjectID = project.ProjectID,
+                UserRole = "follower",
+                IsFollowing = true
+            };
+
+            await _dbContext.ProjectUsers.AddAsync(projectUser);
+            await _dbContext.SaveChangesAsync();
+
+            _dbContext.Entry(projectUser).Reference(pu => pu.User).Load();
+            _dbContext.Entry(projectUser).Reference(pu => pu.Project).Load();
+
+            return Ok(new
+            {
+                result = projectUser,
+                message = "Project followed successfully."
+            });
+        }
+
+        /*
+         * Type : DELETE
+         * URL : /api/project/unfollowproject/{projectID}
+         * Description: Unfollow a project as the authenticated user.
+         *
+         * Request example:
+         * DELETE /api/project/unfollowproject/42
+         *
+         * Response example:
+         * {
+         *   "result": {
+         *     "userID": 5,
+         *     "projectID": 42,
+         *     "userRole": "follower",
+         *     "isFollowing": false
+         *   },
+         *   "message": "Project unfollowed successfully."
+         * }
+         */
+        [Authorize]
+        [HttpDelete("[action]/{projectID}")]
+        public async Task<IActionResult> UnfollowProject([FromRoute] int projectID)
+        {
+            if (projectID <= 0)
+                return BadRequest(new { message = "Invalid project id." });
+
+            // Find User
+            var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (string.IsNullOrEmpty(userIdClaim) || !int.TryParse(userIdClaim, out var userId))
+            {
+                return Unauthorized(new { message = "Invalid user identifier." });
+            }
+
+            var user = await _dbContext.Users.SingleOrDefaultAsync(u => u.Id == userId);
+            if (user == null) return NotFound(new { message = "Current user not found" });
+
+            var project = await _dbContext.Projects.FindAsync(projectID);
+            if (project == null) return NotFound(new { message = "Project Not Found" });
+
+            var projectUser = await _dbContext.ProjectUsers.FindAsync(user.Id, projectID);
+            if (projectUser == null)
+            {
+                return NotFound(new { message = "Project follow record not found." });
+            }
+
+            if (!string.Equals(projectUser.UserRole, "follower", StringComparison.OrdinalIgnoreCase))
+            {
+                return Conflict(new
+                {
+                    result = projectUser,
+                    message = "Project membership already exists and cannot be changed to an unfollow record."
+                });
+            }
+
+            if (!projectUser.IsFollowing)
+            {
+                return Ok(new
+                {
+                    result = projectUser,
+                    message = "Project is already unfollowed."
+                });
+            }
+
+            projectUser.IsFollowing = false;
+            _dbContext.Entry(projectUser).State = EntityState.Modified;
+            await _dbContext.SaveChangesAsync();
+
+            return Ok(new
+            {
+                result = projectUser,
+                message = "Project unfollowed successfully."
+            });
+        }
+
+        /*
+         * Type : POST
          * URL : /api/project/addtag
          * Param : ProjectTagViewModel
          * Description: Add Tag To Project

--- a/src/Analysim.Web/Controllers/ProjectController.cs
+++ b/src/Analysim.Web/Controllers/ProjectController.cs
@@ -1,4 +1,6 @@
-﻿using Internal;
+﻿#nullable enable annotations
+
+using Internal;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Microsoft.AspNetCore.Mvc;
@@ -1147,7 +1149,7 @@ namespace Web.Controllers
                         );
                     }
                 }
-                catch (Exception ex){}
+                catch (Exception) {}
             }
 
             // Return 

--- a/src/Analysim.Web/ViewModels/Project/CreateProjectLogVM.cs
+++ b/src/Analysim.Web/ViewModels/Project/CreateProjectLogVM.cs
@@ -1,3 +1,5 @@
+#nullable enable annotations
+
 using Microsoft.AspNetCore.Http;
 using System.ComponentModel.DataAnnotations;
 

--- a/src/Analysim.Web/ViewModels/Project/CreatePublicationVM.cs
+++ b/src/Analysim.Web/ViewModels/Project/CreatePublicationVM.cs
@@ -1,3 +1,5 @@
+#nullable enable annotations
+
 using System.ComponentModel.DataAnnotations;
 
 namespace Analysim.Web.ViewModels.Project

--- a/src/Analysim.Web/ViewModels/Project/ExpiredProjectLogVM.cs
+++ b/src/Analysim.Web/ViewModels/Project/ExpiredProjectLogVM.cs
@@ -1,3 +1,5 @@
+#nullable enable annotations
+
 using System;
 using System.Collections.Generic;
 

--- a/src/Analysim.Web/ViewModels/Project/ProjectCommentVM.cs
+++ b/src/Analysim.Web/ViewModels/Project/ProjectCommentVM.cs
@@ -1,3 +1,5 @@
+#nullable enable annotations
+
 using System;
 using System.Collections.Generic;
 

--- a/src/Analysim.Web/ViewModels/Project/ProjectLogVM.cs
+++ b/src/Analysim.Web/ViewModels/Project/ProjectLogVM.cs
@@ -1,3 +1,5 @@
+#nullable enable annotations
+
 using System;
 using System.Collections.Generic;
 

--- a/src/Analysim.Web/ViewModels/Project/PublicationVM.cs
+++ b/src/Analysim.Web/ViewModels/Project/PublicationVM.cs
@@ -1,3 +1,5 @@
+#nullable enable annotations
+
 using System;
 using System.Collections.Generic;
 

--- a/src/Analysim.Web/ViewModels/Project/UpdateProjectLogVM.cs
+++ b/src/Analysim.Web/ViewModels/Project/UpdateProjectLogVM.cs
@@ -1,3 +1,5 @@
+#nullable enable annotations
+
 using Microsoft.AspNetCore.Http;
 using System.ComponentModel.DataAnnotations;
 


### PR DESCRIPTION
This PR adds dedicated project follow/unfollow APIs on the backend and updates the Angular frontend to use them instead of the older generic project-user mutation flow. The UI now performs follow/unfollow actions with optimistic updates and disables the controls while requests are in flight, keeping the project card and project detail views in sync with the new endpoints.